### PR TITLE
Mudando o campo de impostos estimados de compute para ser usar o _update_taxes

### DIFF
--- a/l10n_br_account/models/account_tax.py
+++ b/l10n_br_account/models/account_tax.py
@@ -36,7 +36,8 @@ class AccountTax(models.Model):
         fiscal_price=None,
         fiscal_quantity=None,
         uot=None,
-        icmssn_range=None
+        icmssn_range=None,
+        icms_origin=None
     ):
         """ Returns all information required to apply taxes
             (in self + their children in case of a tax goup).
@@ -87,7 +88,8 @@ class AccountTax(models.Model):
             other_costs_value=other_costs_value,
             freight_value=freight_value,
             operation_line=operation_line,
-            icmssn_range=icmssn_range)
+            icmssn_range=icmssn_range,
+            icms_origin=icms_origin or product.icms_origin)
 
         account_taxes_by_domain = {}
         for tax in self:

--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -52,9 +52,9 @@ class DataNcmNbsAbstract(models.AbstractModel):
     @api.depends('tax_estimate_ids')
     def _compute_amount(self):
         for record in self:
-            last_estimated = record.env['l10n_br_fiscal.tax.estimate'].search(
-                [('ncm_id', '=', record.id),
-                 ('company_id', '=', record.env.user.company_id.id)],
+            last_estimated = record.env['l10n_br_fiscal.tax.estimate'].search([
+                '|', ('ncm_id', '=', record.id),('nbs_id', '=', record.id),
+                ('company_id', '=', record.env.user.company_id.id)],
                 order='create_date DESC',
                 limit=1)
 

--- a/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
+++ b/l10n_br_fiscal/models/data_ncm_nbs_abstract.py
@@ -53,7 +53,7 @@ class DataNcmNbsAbstract(models.AbstractModel):
     def _compute_amount(self):
         for record in self:
             last_estimated = record.env['l10n_br_fiscal.tax.estimate'].search([
-                '|', ('ncm_id', '=', record.id),('nbs_id', '=', record.id),
+                '|', ('ncm_id', '=', record.id), ('nbs_id', '=', record.id),
                 ('company_id', '=', record.env.user.company_id.id)],
                 order='create_date DESC',
                 limit=1)

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -122,6 +122,8 @@ class Document(models.Model):
                 line.amount_financial for line in record.line_ids)
             record.amount_tax_withholding = sum(
                 line.amount_tax_withholding for line in record.line_ids)
+            record.amount_estimate_tax = sum(
+                line.amount_estimate_tax for line in record.line_ids)
 
     # used mostly to enable _inherits of account.invoice on
     # fiscal_document when existing invoices have no fiscal document.
@@ -579,6 +581,12 @@ class Document(models.Model):
     amount_inss_wh_value = fields.Monetary(
         string='INSS Ret Value',
         compute='_compute_amount',
+    )
+
+    amount_estimate_tax = fields.Monetary(
+        string='Amount Estimate Tax',
+        compute='_compute_amount',
+        default=0.00,
     )
 
     amount_tax = fields.Monetary(

--- a/l10n_br_fiscal/models/document.py
+++ b/l10n_br_fiscal/models/document.py
@@ -586,7 +586,6 @@ class Document(models.Model):
     amount_estimate_tax = fields.Monetary(
         string='Amount Estimate Tax',
         compute='_compute_amount',
-        default=0.00,
     )
 
     amount_tax = fields.Monetary(

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin.py
@@ -743,3 +743,7 @@ class FiscalDocumentLineMixin(models.AbstractModel):
     )
 
     additional_data = fields.Char(string='Additional Data')
+
+    amount_estimate_tax = fields.Monetary(
+        string='Amount Estimate Tax',
+    )

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -366,6 +366,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.ncm_id = self.product_id.ncm_id
             self.nbm_id = self.product_id.nbm_id
             self.tax_icms_or_issqn = self.product_id.tax_icms_or_issqn
+            self.icms_origin = self.product_id.icms_origin
             self.cest_id = self.product_id.cest_id
             self.nbs_id = self.product_id.nbs_id
             self.fiscal_genre_id = self.product_id.fiscal_genre_id
@@ -378,6 +379,7 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             self.ncm_id = False
             self.nbm_id = False
             self.tax_icms_or_issqn = False
+            self.icms_origin = False
             self.cest_id = False
             self.nbs_id = False
             self.fiscal_genre_id = False

--- a/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
+++ b/l10n_br_fiscal/models/document_fiscal_line_mixin_methods.py
@@ -149,7 +149,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
             nbm=self.nbm_id,
             cest=self.cest_id,
             operation_line=self.fiscal_operation_line_id,
-            icmssn_range=self.icmssn_range_id)
+            icmssn_range=self.icmssn_range_id,
+            icms_origin=self.icms_origin)
 
     @api.multi
     def _prepare_br_fiscal_dict(self, default=False):
@@ -226,6 +227,8 @@ class FiscalDocumentLineMixinMethods(models.AbstractModel):
                 'amount_not_included', 0.0)
             l.amount_tax_withholding = compute_result.get(
                 'amount_withholding', 0.0)
+            l.amount_estimate_tax = compute_result.get(
+                'amount_estimate_tax', 0.0)
             for tax in l.fiscal_tax_ids:
 
                 computed_tax = computed_taxes.get(tax.tax_domain, {})

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -71,23 +71,6 @@ class DocumentLine(models.Model):
                 record.amount_tax_withholding
             )
 
-            # Amount Estimate Tax
-            if record.fiscal_operation_type == FISCAL_OUT and \
-                    record.fiscal_operation_id.fiscal_type == 'sale':
-                if record.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
-                    record.amount_estimate_tax = \
-                        record.amount_total * (
-                            record.nbs_id.estimate_tax_national / 100)
-                else:
-                    if record.icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
-                        record.amount_estimate_tax = \
-                            record.amount_total * (
-                                record.ncm_id.estimate_tax_imported / 100)
-                    else:
-                        record.amount_estimate_tax = \
-                            record.amount_total * (
-                                record.ncm_id.estimate_tax_national / 100)
-
     @api.model
     def _operation_domain(self):
         domain = [('state', '=', 'approved')]
@@ -142,10 +125,6 @@ class DocumentLine(models.Model):
     )
 
     # Amount Fields
-    amount_estimate_tax = fields.Monetary(
-        string='Amount Estimate Tax',
-    )
-
     amount_untaxed = fields.Monetary(
         string='Amount Untaxed',
         compute='_compute_amount',

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -144,7 +144,6 @@ class DocumentLine(models.Model):
     # Amount Fields
     amount_estimate_tax = fields.Monetary(
         string='Amount Estimate Tax',
-        default=0.00,
     )
 
     amount_untaxed = fields.Monetary(

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -65,11 +65,11 @@ class DocumentLine(models.Model):
 
             # Amount Estimate Tax
             if record.product_id.icms_origin in ['1', '2', '6', '7']:
-                record.amount_estimate_tax = record.amount_total * \
-                                             (record.ncm_id.estimate_tax_imported / 100)
+                record.amount_estimate_tax = \
+                    record.amount_total * (record.ncm_id.estimate_tax_imported / 100)
             else:
-                record.amount_estimate_tax = record.amount_total * \
-                                             (record.ncm_id.estimate_tax_national / 100)
+                record.amount_estimate_tax = \
+                    record.amount_total * (record.ncm_id.estimate_tax_national / 100)
 
     @api.model
     def _operation_domain(self):

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -3,8 +3,14 @@
 
 from odoo import api, fields, models
 
-from ..constants.fiscal import TAX_FRAMEWORK
+from ..constants.fiscal import (
+    TAX_FRAMEWORK,
+    TAX_DOMAIN_ISSQN
+)
 
+from ..constants.icms import (
+    ICMS_ORIGIN_TAX_IMPORTED
+)
 
 class DocumentLine(models.Model):
     _name = 'l10n_br_fiscal.document.line'
@@ -64,12 +70,16 @@ class DocumentLine(models.Model):
             )
 
             # Amount Estimate Tax
-            if record.product_id.icms_origin in ['1', '2', '6', '7']:
+            if record.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
                 record.amount_estimate_tax = \
-                    record.amount_total * (record.ncm_id.estimate_tax_imported / 100)
+                    record.amount_total * (record.nbs_id.estimate_tax_national / 100)
             else:
-                record.amount_estimate_tax = \
-                    record.amount_total * (record.ncm_id.estimate_tax_national / 100)
+                if record.icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
+                    record.amount_estimate_tax = \
+                        record.amount_total * (record.ncm_id.estimate_tax_imported / 100)
+                else:
+                    record.amount_estimate_tax = \
+                        record.amount_total * (record.ncm_id.estimate_tax_national / 100)
 
     @api.model
     def _operation_domain(self):

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -63,6 +63,14 @@ class DocumentLine(models.Model):
                 record.amount_tax_withholding
             )
 
+            # Amount Estimate Tax
+            if record.product_id.icms_origin in ['1', '2', '6', '7']:
+                record.amount_estimate_tax = record.amount_total * \
+                                             (record.ncm_id.estimate_tax_imported / 100)
+            else:
+                record.amount_estimate_tax = record.amount_total * \
+                                             (record.ncm_id.estimate_tax_national / 100)
+
     @api.model
     def _operation_domain(self):
         domain = [('state', '=', 'approved')]
@@ -118,7 +126,7 @@ class DocumentLine(models.Model):
 
     # Amount Fields
     amount_estimate_tax = fields.Monetary(
-        string='Amount Estimate Total',
+        string='Amount Estimate Tax',
         compute='_compute_amount',
         default=0.00,
     )

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -5,7 +5,8 @@ from odoo import api, fields, models
 
 from ..constants.fiscal import (
     TAX_FRAMEWORK,
-    TAX_DOMAIN_ISSQN
+    TAX_DOMAIN_ISSQN,
+    FISCAL_OUT
 )
 
 from ..constants.icms import (
@@ -71,19 +72,21 @@ class DocumentLine(models.Model):
             )
 
             # Amount Estimate Tax
-            if record.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
-                record.amount_estimate_tax = \
-                    record.amount_total * (
-                        record.nbs_id.estimate_tax_national / 100)
-            else:
-                if record.icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
+            if record.fiscal_operation_type == FISCAL_OUT and \
+                    record.fiscal_operation_id.fiscal_type == 'sale':
+                if record.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
                     record.amount_estimate_tax = \
                         record.amount_total * (
-                            record.ncm_id.estimate_tax_imported / 100)
+                            record.nbs_id.estimate_tax_national / 100)
                 else:
-                    record.amount_estimate_tax = \
-                        record.amount_total * (
-                            record.ncm_id.estimate_tax_national / 100)
+                    if record.icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
+                        record.amount_estimate_tax = \
+                            record.amount_total * (
+                                record.ncm_id.estimate_tax_imported / 100)
+                    else:
+                        record.amount_estimate_tax = \
+                            record.amount_total * (
+                                record.ncm_id.estimate_tax_national / 100)
 
     @api.model
     def _operation_domain(self):
@@ -141,7 +144,6 @@ class DocumentLine(models.Model):
     # Amount Fields
     amount_estimate_tax = fields.Monetary(
         string='Amount Estimate Tax',
-        compute='_compute_amount',
         default=0.00,
     )
 

--- a/l10n_br_fiscal/models/document_line.py
+++ b/l10n_br_fiscal/models/document_line.py
@@ -12,6 +12,7 @@ from ..constants.icms import (
     ICMS_ORIGIN_TAX_IMPORTED
 )
 
+
 class DocumentLine(models.Model):
     _name = 'l10n_br_fiscal.document.line'
     _inherit = 'l10n_br_fiscal.document.line.mixin'
@@ -72,14 +73,17 @@ class DocumentLine(models.Model):
             # Amount Estimate Tax
             if record.tax_icms_or_issqn == TAX_DOMAIN_ISSQN:
                 record.amount_estimate_tax = \
-                    record.amount_total * (record.nbs_id.estimate_tax_national / 100)
+                    record.amount_total * (
+                        record.nbs_id.estimate_tax_national / 100)
             else:
                 if record.icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
                     record.amount_estimate_tax = \
-                        record.amount_total * (record.ncm_id.estimate_tax_imported / 100)
+                        record.amount_total * (
+                            record.ncm_id.estimate_tax_imported / 100)
                 else:
                     record.amount_estimate_tax = \
-                        record.amount_total * (record.ncm_id.estimate_tax_national / 100)
+                        record.amount_total * (
+                            record.ncm_id.estimate_tax_national / 100)
 
     @api.model
     def _operation_domain(self):

--- a/l10n_br_fiscal/models/tax.py
+++ b/l10n_br_fiscal/models/tax.py
@@ -25,7 +25,8 @@ from ..constants.icms import (
     ICMS_SN_CST_WITH_CREDIT,
     ICMS_DIFAL_PARTITION,
     ICMS_DIFAL_UNIQUE_BASE,
-    ICMS_DIFAL_DOUBLE_BASE
+    ICMS_DIFAL_DOUBLE_BASE,
+    ICMS_ORIGIN_TAX_IMPORTED,
 )
 
 
@@ -303,6 +304,36 @@ class Tax(models.Model):
                 precision)
 
         return tax_dict
+
+    def _compute_estimate_taxes(self, **kwargs):
+        company = kwargs.get("company")
+        product = kwargs.get("product")
+        fiscal_price = kwargs.get("fiscal_price")
+        fiscal_quantity = kwargs.get("fiscal_quantity")
+        currency = kwargs.get("currency", company.currency_id)
+        precision = currency.decimal_places
+        ncm = kwargs.get("ncm") or product.ncm_id
+        nbs = kwargs.get("nbs") or product.nbs_id
+        icms_origin = kwargs.get("icms_origin") or product.icms_origin
+        op_line = kwargs.get("operation_line")
+        amount_estimate_tax = 0.00
+        amount_total = round(fiscal_price * fiscal_quantity, precision)
+
+        if op_line and (op_line.fiscal_operation_type == FISCAL_OUT
+                and op_line.fiscal_operation_id.fiscal_type == 'sale'):
+            if nbs:
+                amount_estimate_tax =  round(amount_total * (
+                        record.nbs_id.estimate_tax_national / 100), precision)
+            else:
+                if ncm:
+                    if icms_origin in ICMS_ORIGIN_TAX_IMPORTED:
+                        amount_estimate_tax = round(amount_total * (
+                                ncm.estimate_tax_imported / 100), precision)
+                    else:
+                        amount_estimate_tax = round(amount_total * (
+                                ncm.estimate_tax_national / 100), precision)
+
+        return amount_estimate_tax
 
     def _compute_icms(self, tax, taxes_dict, **kwargs):
         partner = kwargs.get("partner")
@@ -603,7 +634,8 @@ class Tax(models.Model):
             nbm,
             cest,
             operation_line,
-            icmssn_range
+            icmssn_range,
+            icms_origin,
         return
             {
                 'amount_included': float
@@ -616,6 +648,7 @@ class Tax(models.Model):
             'amount_included': 0.00,
             'amount_not_included': 0.00,
             'amount_withholding': 0.00,
+            'amount_estimate_tax': 0.00,
             'taxes': {},
         }
         taxes = {}
@@ -651,6 +684,10 @@ class Tax(models.Model):
                 # Caso não exista campos especificos dos impostos
                 # no documento fiscal, os mesmos são calculados.
                 continue
+
+        # Estimate taxes
+        result_amounts['amount_estimate_tax'] = self._compute_estimate_taxes(
+            **kwargs)
         result_amounts['taxes'] = taxes
         return result_amounts
 

--- a/l10n_br_fiscal/views/document_view.xml
+++ b/l10n_br_fiscal/views/document_view.xml
@@ -280,6 +280,7 @@
                     <field name="amount_insurance_value"/>
                     <field name="amount_other_costs_value"/>
                     <field name="amount_freight_value"/>
+                    <field name="amount_estimate_tax"/>
                     <field name="amount_tax"/>
                     <field name="amount_total"/>
                     <field name="amount_tax_withholding"/>


### PR DESCRIPTION
Olá Marcel esse campo não deveria ser um compute porque nas entradas devemos preencher o valor que vem da NF-e de entrada, então eu movi o calculo dos impostos estimados para o fiscal.tax e no compute_taxes ele retorna uma chave com o valor dos impostos estimados.