### PR TITLE
[14.0][MIG] l10n_br_stock_account

### DIFF
--- a/l10n_br_stock_account/models/__init__.py
+++ b/l10n_br_stock_account/models/__init__.py
@@ -7,3 +7,4 @@ from . import stock_picking_type
 from . import stock_picking
 from . import stock_move
 from . import procurement_group
+from . import account_move

--- a/l10n_br_stock_account/models/account_move.py
+++ b/l10n_br_stock_account/models/account_move.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2022-Today - Akretion (<http://www.akretion.com>).
+# @author Magno Costa <magno.costa@akretion.com.br>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    @api.constrains('move_type', 'journal_id')
+    def _check_journal_type(self):
+        # A implementação do modulo stock_picking_invoicing é justamente o caso
+        # de ser preciso ter um Documento Fiscal mas não ser nem uma Venda nem
+        # uma Compra é por exemplo uma Transferencia entre Filiais, Remessa para
+        # Conserto e etc por padrão apenas os casos onde o campo Type do
+        # account.journal são ou sale ou purchase permitem a criação da Invoice
+        # por isso o metodo está sendo sobre escrito aqui.
+        # TODO - isso deveria estar no modulo stock_picking_invoicing?
+        for record in self:
+            if record.picking_ids:
+                inv_gen_from_picking = False
+                pickings_name = record.picking_ids.mapped("name")
+                list_invoice_origin = record.invoice_origin.split(", ")
+                for picking_name in pickings_name:
+                    if picking_name in list_invoice_origin:
+                        picking = record.picking_ids.filtered(
+                            lambda x: x.name == picking_name
+                        )
+                        # Se tiver um Pedido de Venda ou Compra relacionado
+                        # deve ser feita a validação
+                        has_sale_or_purchase = False
+                        if hasattr(picking, "sale_id"):
+                            if picking.sale_id:
+                                has_sale_or_purchase = True
+                        if hasattr(picking, "purchase_id"):
+                            if picking.purchase_id:
+                                has_sale_or_purchase = True
+
+                        if has_sale_or_purchase:
+                            continue
+
+                        inv_gen_from_picking = True
+
+                # Não deve ser validado porque foi gerado pelo stock.picking
+                if inv_gen_from_picking:
+                    return False
+
+                return super()._check_journal_type()

--- a/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
+++ b/l10n_br_stock_account/wizards/stock_invoice_onshipping.py
@@ -125,11 +125,6 @@ class StockInvoiceOnshipping(models.TransientModel):
         if move.fiscal_operation_line_id:
             # Linhas de Operações Fiscais diferentes
             # não podem ser agrupadas
-            if type(key) is tuple:
-                key = key + (move.fiscal_operation_line_id,)
-            else:
-                # TODO - seria melhor identificar o TYPE para saber se
-                #  o KEY realmente é um objeto nesse caso
-                key = (key, move.fiscal_operation_line_id)
+            key = key + (move.fiscal_operation_line_id,)
 
         return key


### PR DESCRIPTION
Olá @marcelsavegnago @renatonlima @rvalyi @felipemotter nesse PR estou considerando que vamos sobre escrever a constraint do Tipo do Diário na criação da Fatura, como escrevi no PR de migração na OCA https://github.com/OCA/l10n-brazil/pull/1937, bom isso pode acontecer ou não dependendo da decisão que for tomada( aguardo para ouvir a opinião de todos porque se for isso mesmo provavelmente isso deverá ser feito no stock_picking_invoicing ), esse commit especifico está separado e assim pode ser feito o cherry-pick das outras alterações que foram:

- Nos testes o campo invoice_line_tax_ids passou para apenas tax_ids e o objeto stock.overprocessed.transfer deixou de existir
- No metodo _get_picking_key a partir da v14 passou a sempre retornar uma tupla https://github.com/OCA/account-invoicing/blob/14.0/stock_picking_invoicing/wizards/stock_invoice_onshipping.py#L301 assim não existi a necessidade de manter essa verificação no l10n_br_stock_account

Os testes quando feitos de forma a instalar o l10n_br_account e em seguida o l10n_br_stock_account e testar estão passando porém ao simular os mesmo comandos feitos no Travis https://app.travis-ci.com/github/OCA/l10n-brazil/jobs/578742682#L820 e https://app.travis-ci.com/github/OCA/l10n-brazil/jobs/578742682#L2277 o campo dos tax_ids nas linhas vem vazio o problema acontece no momento de se fazer o browse dos IDs aqui https://github.com/akretion/l10n-brazil/blob/14.0-mig-AK-l10n_br_stock_account/l10n_br_stock_account/wizards/stock_invoice_onshipping.py#L105 a variavel fiscal_values["fiscal_tax_ids"] tem valor mas o browse não encontra nada, talvez seja algo ligado a Empresa/company ainda não encontrei o motivo, se alguém tiver alguma ideia ou pista sobre o que pode ser agradeço.