### PR TITLE
[FIX] l10n_br_sale: partner_invoice_id for taxes

### DIFF
--- a/l10n_br_sale/models/sale_order_line.py
+++ b/l10n_br_sale/models/sale_order_line.py
@@ -67,7 +67,7 @@ class SaleOrderLine(models.Model):
 
     partner_id = fields.Many2one(
         comodel_name="res.partner",
-        related="order_id.partner_id",
+        related="order_id.partner_invoice_id",
         string="Partner",
     )
 


### PR DESCRIPTION
usa o order_id.partner_invoice_id pros calculos de impostos do Brasil